### PR TITLE
make pacli-simple an optdepend

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -10,7 +10,8 @@ license=MIT
 depends=('mhwd'
 	'awk'
 	'bash')
-optdepends=('pacli: package management menu item')
+optdepends=('pacli: package management menu item'
+	'pacli-simple: package management menu item')
 makedepends=('git')
 source=("git://github.com/Chrysostomus/$pkgname")
 md5sums=('SKIP')


### PR DESCRIPTION
pacli-simple works as well as pacli and it does not require any changes in mhwd-tui itself.

please add this.